### PR TITLE
Link fixes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a set of documents which describes Gogs REST API v1 usage, since it's st
 2. We do not provide documentation in other languages.
 3. Aim to be in the format that is similar to [GitHub REST API v3](https://developer.github.com/v3/).
 
-If you have any questions or concern, please [file an issue](https://github.com/gogits/go-gogs-client/issues/new). :blush:
+If you have any questions or concern, please [file an issue](https://github.com/gogs/go-gogs-client/issues/new). :blush:
 
 ## TOC
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you have any questions or concern, please [file an issue](https://github.com/
 
 ## Installation 
 
-The API is preinstalled with the base Gogs deployment. See [current version](#current-version) and [API source code](https://github.com/gogs/gogs/tree/master/routes/api) for more details.
+The API is preinstalled with the base Gogs deployment. See [current version](#current-version) and [API source code](https://github.com/gogs/gogs/tree/master/internal/route/api) for more details.
 
 ## Current Version
 


### PR DESCRIPTION
This PR fixes a couple of links in the README.  Primarily this is for the API source code link that points to the old source path in `gogs/master` (`/routes/api/...` → `/internal/route/api/...`).  I also noticed there was an old `gogits` URL for the new issue link so I changed that too.