### PR TITLE
remove broken link for tree api doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ If you have any questions or concern, please [file an issue](https://github.com/
   - [Commits](Repositories/Commits.md)
   - [Contents](Repositories/Contents.md)
   - [Deploy Keys](Repositories/Deploy%20Keys.md)
-  - [Tree](Repositories/Tree.md)
   - [Webhooks](Repositories/Webhooks.md)
 - [Users](Users)
   - [Emails](Users/Emails.md)


### PR DESCRIPTION
This PR removes the broken link for trees api doc.

It seems like it was left behind, when it was moved under Git Data.