### PR TITLE
add reference to Bash CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ The possible rel values are:
 
 - [Go](https://github.com/gogs/go-gogs-client)
 - [Android](https://github.com/unfoldingWord-dev/android-gogs-client)
+- [Bash](https://github.com/grogorick/gogs-cli)
 
 ## Notes
 


### PR DESCRIPTION
Hi, I'm not sure if you want to consider a simple CLI implementation as a "client". Just in case you do, I've added a reference.

It was originally created to manage larger numbers of student teams for practical courses at our lab, but I thought it might also be useful to others.